### PR TITLE
グーグルログインを見つけやすく、押しやすい位置に移動

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,9 +9,9 @@
   </head>
 
   <body>
-    <div class="container">
+    <div style="margin-top: 30px" class="container">
       <%#debag用%>
-      <%= login? %>
+      <div style="font-size: 250%"><%= login? %></div>
       <%= yield %>
     </div>
   </body>


### PR DESCRIPTION
ログインリンクが小さすぎて、見つけられない & タップしにくい という意見があったので応急処置として無理やり場所と大きさを変更してみました。